### PR TITLE
Don't print the first separator if no critiques

### DIFF
--- a/lisp-critic.lisp
+++ b/lisp-critic.lisp
@@ -240,7 +240,8 @@ forgot the USE-PACKAGE. Do this to fix things:
 (defun print-critique-responses (critiques
                                  &optional (stream *standard-output*))
   (let ((*print-pretty* nil))
-    (print-separator stream)
+    (when critiques
+      (print-separator stream))
     (dolist (critique critiques)
       (print-critique-response critique stream))))
 


### PR DESCRIPTION
Hello,

Here's a little commit to make the lisp-critic no obtrusive when it has nothing to say.

Best,