### PR TITLE
style: consing on alist with ACONS & multiple optional arguments to &KEY

### DIFF
--- a/extend-match.lisp
+++ b/extend-match.lisp
@@ -227,7 +227,7 @@
   (assoc name bindings))
 
 (defun add-binding (name input blists)
-  (list (cons (cons name input) (first blists))))
+  (list (acons name input (first blists))))
 
 (defun binding-variable (binding) (first binding))
 

--- a/lisp-critic.lisp
+++ b/lisp-critic.lisp
@@ -235,7 +235,7 @@ forgot the USE-PACKAGE. Do this to fix things:
         append (apply-critique-rule name code)))
 
 (defun apply-critique-rule (name code)
-  (find-critiques name (get-pattern name) code '(nil) t))
+  (find-critiques name (get-pattern name) code :blists '(nil) :*top-level* t))
 
 (defun print-critique-responses (critiques
                                  &optional (stream *standard-output*))
@@ -250,14 +250,14 @@ forgot the USE-PACKAGE. Do this to fix things:
 ;;; FIND-CRITIQUES
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defun find-critiques (name pat code &optional (blists '(nil)) *top-level*)
+(defun find-critiques (name pat code &key (blists '(nil)) *top-level*)
   (let ((new-blists (critique-match pat code blists)))
     (cond ((not (null new-blists))
            (make-critiques name new-blists code))
       ((atom code) nil)
        (t
-       (or (find-critiques name pat (car code) blists)
-           (find-critiques name pat (cdr code) blists))))))
+       (or (find-critiques name pat (car code) :blists blists)
+           (find-critiques name pat (cdr code) :blists blists))))))
 
 
 (defun critique-match (pat code blists)

--- a/write-wrap.lisp
+++ b/write-wrap.lisp
@@ -50,7 +50,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 ;;; in 6.0!
 
 (defun write-wrap (stream strng width
-                          &optional indent (first-indent indent))
+                          &key indent (first-indent indent))
   (let ((*print-pretty* nil))
     (do* ((end (length strng))
           (indent-string (when (and indent (> indent 0))


### PR DESCRIPTION
These changes are to comply with `LISP-CRITIC` own rules:

- **[cons-cons-alist]** is fixed in the function `add-binding`
- **[optionals]** is fixed in the internal functions `find-critiques`, and `write-wrap`

There are more cases of **[optionals]** (mostly) in exported functions, but changing these optional parameter to keywords would be a breaking change and should probably be addressed separately.